### PR TITLE
Fixed regexp so it also handles camelcase variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ Vars.prototype.set = function(name, value) {
 Vars.prototype.replace = function(node, key) {
     if(node && typeof key === 'string') {
         var value = node[key],
-            vars = value.match(/(@{?[a-z0-9-_.]+}?)/g);
+            vars = value.match(/(@{?[a-zA-Z0-9-_.]+}?)/g);
 
         if(vars) {
             vars.forEach(function(item) {


### PR DESCRIPTION
Fixes issue https://github.com/lamo2k123/postcss-less-vars/issues/7.

Verified working on osx with webpack.